### PR TITLE
AOF-10 Ensure that when we are viewing a contribution we don't accidentially…

### DIFF
--- a/templates/CRM/PaymentInfo.tpl
+++ b/templates/CRM/PaymentInfo.tpl
@@ -35,7 +35,7 @@
     if ($('.payment-details_group').length) {
       var paymentsTable = $('.payment-details_group').find('table');
     } else {
-      var paymentsTable = $('.crm-info-panel').find('table');
+      var paymentsTable = $('.crm-info-panel').find('table.selector.row-highlight');
     }
     $(paymentsTable).replaceWith('<table class="selector row-highlight">' + $('#newPaymentTable').html() + '</table>');
   });


### PR DESCRIPTION
… clobber the line item table as well

This fixes an issue that the previous fix caused which is that when viewing a contribution it clobbers the Line item section as well as per the screenshots

Before:

![PR-before](https://user-images.githubusercontent.com/6799125/72577617-908eb200-3927-11ea-842f-d996c37f712a.jpg)

After:

![pr-after](https://user-images.githubusercontent.com/6799125/72577628-95ebfc80-3927-11ea-9e1f-eda1e217aecf.jpg)
