### PR TITLE
AOF-33 Fix multiple issues involving recurring contributions and chap…

### DIFF
--- a/CRM/EFT/BAO/EFT.php
+++ b/CRM/EFT/BAO/EFT.php
@@ -160,18 +160,25 @@ class CRM_EFT_BAO_EFT extends CRM_EFT_DAO_EFT {
         if (!empty($chapter)) {
           $params['chapter'] = $chapter;
         }
+        if (!empty($fund) && !is_array($fund)) {
+          $params['fund'] = $fund;
+        }
         if (!empty($lineItemChapterFund)) {
           if (empty($params['chapter'])) {
             $params['chapter'] = $lineItemChapterFund['chapter_code'];
           }
-          $params['fund'] = $lineItemChapterFund['fund_code'];
+          if (empty($params['fund'])) {
+            $params['fund'] = $lineItemChapterFund['fund_code'];
+          }
         }
         elseif (!$fund['isMembership'] && !$isPriceSet) {
           $chapterFund = self::getChapterFund($contributionPageId, "civicrm_contribution_page");
           if (empty($params['chapter'])) {
             $params['chapter'] = $chapterFund['chapter_code'];
           }
-          $params['fund'] = $chapterFund['fund_code'];
+          if (empty($params['fund'])) {
+            $params['fund'] = $chapterFund['fund_code'];
+          }
         }
         elseif (!$fund['isMembership'] && $isPriceSet) {
           $originalFund = self::getChapterFund($fund['memType'], "civicrm_membership_type");
@@ -237,6 +244,10 @@ class CRM_EFT_BAO_EFT extends CRM_EFT_DAO_EFT {
         // Use the supplied chapter if we have it.
         if (!empty($chapter)) {
           $chapterFund['chapter_code'] = $chapter;
+        }
+        // Use the supplied fund if we have it.
+        if (!empty($fund) && !is_array($fund)) {
+          $chapterFund['fund_code'] = $fund;
         }
       }
       if (!empty($chapterFund)) {

--- a/extendfinancialtype.php
+++ b/extendfinancialtype.php
@@ -570,6 +570,14 @@ function extendfinancialtype_civicrm_pre($op, $objectName, $objectId, &$objectRe
       $objectRef['financial_type_id'] = $ft;
     }
   }
+  // Ensure that Contribution Recur objects have the same financial type as for the linked Contribution.
+  if ($objectName == 'ContributionRecur' && $op == 'create') {
+    $giftType = CRM_Core_Session::singleton()->get('giftType');
+    list($code, $ft) = addGiftFT($giftType);
+    if (!empty($ft)) {
+      $objectRef['financial_type_id'] = $ft;
+    }
+  }
 }
 
 function addGiftFT($giftType) {
@@ -979,7 +987,7 @@ function extendfinancialtype_civicrm_postProcess($formName, &$form) {
 
     if ($form->_id == DONATION_PAGE) {
       if ($submitChapter = CRM_Utils_Array::value('chapter_code', $form->_params, NULL)) {
-        $fts = CRM_EFT_BAO_EFT::addChapterFund($submitChapter, $submitChapter, $form->_contributionID, "civicrm_line_item", TRUE);
+        $fts = CRM_EFT_BAO_EFT::addChapterFund($submitChapter, $submitChapter, $form->_contributionID, 'civicrm_contribution_page_online', TRUE, $form->_id);
         // Add chapter and fund for recurring contributions.
         if (CRM_Utils_Array::value('is_recur', $form->_values)) {
           CRM_EFT_BAO_EFT::addChapterFund($submitChapter, $submitChapter, $form->_params['contributionRecurID'], "civicrm_contribution_recur", TRUE, $form->_id);


### PR DESCRIPTION
…ter nad funds

This PR aims to fix the following items

1) The financial Type on a Contribution Recur object does not match the submitted contribution that can then break things for subsequent contributions. 

2) Ensure that the same chapter and fund is set on the financial item, contribution, contribution recur and line item records in the database.

@Edzelopez It is probably best to test it by selecting a different gift type and chapter to the default ones this is when it really shows up the problem.

I haven't tested what happens on subsequent payments but setting the initial ones should improve the chances  of subsequent contributions being correct. 